### PR TITLE
Replaced dropbox link and added generated altmetrics material to repo

### DIFF
--- a/index.html
+++ b/index.html
@@ -203,7 +203,7 @@ eventbrite: # 18035804577 # optional (delete this if not used, otherwise uncomme
   <p>
     The following links will be useful during the workshop:
     <ul>
-      <li>We have a <a href="https://www.dropbox.com/sh/5c9vez8lhu1xumk/AADu4BQdb4447on2FQ-aJ_OXa?dl=0">dropbox</a> folder that will contain the scripts we are creating and text file of the history of the git lessons.</li>
+      <li>During the bootcamp, we had a dropbox folder that contained the scripts we created and text file of the history of the git lessons. Now that the bootcamp is complete, these files are now located in the bootcamp repo. You can download all of the files that were located in the altmetrics folder <a href="https://jdblischak.github.io/2015-09-15-chicago/SWC_chicago_2015.zip">here</a>.</li>
       <li>Here are two datasets <a href="https://raw.githubusercontent.com/jdblischak/r-intermediate-altmetrics/gh-pages/data/counts-raw.txt.gz">(raw)</a> and <a href="https://raw.githubusercontent.com/jdblischak/r-intermediate-altmetrics/gh-pages/data/counts-norm.txt.gz">(normalized)</a> that we will use in the R section. Right click to save as and save in the altmetrics/data folder.</li>
       <li>Here is a link to the <a href="https://jdblischak.github.io/r-intermediate-altmetrics/">R lesson material</a>.</li>
       <li>Here is a link to the <a href="http://erdavenport.github.io/git-lessons/index.html">git lesson material</a>.</li>


### PR DESCRIPTION
I'm probably going to delete that Dropbox folder, so I've zipped it and put it in the workshop repo. I've updated the index page to include a link to that zipped file. 
